### PR TITLE
Fix to always send messages as binary type

### DIFF
--- a/Assets/Runtime/Internal/IWebSocketClient.cs
+++ b/Assets/Runtime/Internal/IWebSocketClient.cs
@@ -9,11 +9,9 @@ namespace UnityWebSocket
     {
         UniTask ConnectAsync(Uri uri, CancellationToken cancellationToken);
 
-        UniTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
-            CancellationToken cancellationToken);
+        UniTask SendAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken);
 
-        UniTask SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
-            CancellationToken cancellationToken);
+        UniTask SendAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken);
 
         UniTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken);
 

--- a/Assets/Runtime/Internal/WebSocketClientNonWebGL.cs
+++ b/Assets/Runtime/Internal/WebSocketClientNonWebGL.cs
@@ -14,16 +14,14 @@ namespace UnityWebSocket
             await _client.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
         }
 
-        public async UniTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
-            CancellationToken cancellationToken)
+        public async UniTask SendAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            await _client.SendAsync(buffer, messageType, endOfMessage, cancellationToken).ConfigureAwait(false);
+            await _client.SendAsync(buffer, WebSocketMessageType.Binary, true, cancellationToken).ConfigureAwait(false);
         }
 
-        public async UniTask SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
-            CancellationToken cancellationToken)
+        public async UniTask SendAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
         {
-            await _client.SendAsync(buffer, messageType, endOfMessage, cancellationToken).ConfigureAwait(false);
+            await _client.SendAsync(buffer, WebSocketMessageType.Binary, true, cancellationToken).ConfigureAwait(false);
         }
 
         public async UniTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer,

--- a/Assets/Runtime/Internal/WebSocketClientWebGL.cs
+++ b/Assets/Runtime/Internal/WebSocketClientWebGL.cs
@@ -43,8 +43,7 @@ namespace UnityWebSocket
             } while (State is WebSocketState.Connecting);
         }
 
-        public UniTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
-            CancellationToken cancellationToken)
+        public UniTask SendAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
             unsafe
             {
@@ -57,10 +56,9 @@ namespace UnityWebSocket
             return UniTask.CompletedTask;
         }
 
-        public UniTask SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
-            CancellationToken cancellationToken)
+        public UniTask SendAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
         {
-            return SendAsync(buffer.AsMemory(), messageType, endOfMessage, cancellationToken);
+            return SendAsync(buffer.AsMemory(), cancellationToken);
         }
 
         public async UniTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer,

--- a/Assets/Runtime/WebSocketClient.cs
+++ b/Assets/Runtime/WebSocketClient.cs
@@ -7,7 +7,7 @@ namespace UnityWebSocket
 {
     public class WebSocketClient : IDisposable
     {
-        private IWebSocketClient _client;
+        private readonly IWebSocketClient _client;
 
         public WebSocketClient()
         {
@@ -23,16 +23,15 @@ namespace UnityWebSocket
             await _client.ConnectAsync(uri, cancellationToken);
         }
 
-        public async UniTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
-            CancellationToken cancellationToken)
+        public async UniTask SendAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            await _client.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+            await _client.SendAsync(buffer, cancellationToken);
         }
 
         public async UniTask SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
             CancellationToken cancellationToken)
         {
-            await _client.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+            await _client.SendAsync(buffer, cancellationToken);
         }
 
         public async UniTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer,

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Unity WebGL has the limitation that the browser cannot handle the socket API dir
 
 You can add `"com.yoshd.unitywebsocket": "https://github.com/yoshd/UnityWebSocket.git"` to your `manifest.json` .
 
+Messages are always sent in binary type.
+
 ```cs
 using UnityWebSocket;
 
@@ -20,7 +22,7 @@ async UniTask SampleAsync()
 {
     var client = new WebSocketClient();
     var msg = System.Text.Encoding.UTF8.GetBytes("Hello!");
-    await client.SendAsync(msg.AsMemory(), WebSocketMessageType.Binary, true, CancellationToken.None);
+    await client.SendAsync(msg.AsMemory(), CancellationToken.None);
     var buf = new Memory<byte>(new byte[1024]);
     var r = await client.ReceiveAsync(buf, CancellationToken.None);
     await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "close", CancellationToken.None);


### PR DESCRIPTION
This is a breaking change.

When using the WebSocket API in JavaScript for WebGL, the message type was not specified.
Since it is expected that there will be no problem with just binary, it will use only binary as the message type.
Furthermore, it is expected that there will be no problem if all endOfMessage=true.