### PR TITLE
Fix SynchronizationContext switching when not WebGL

### DIFF
--- a/Assets/Runtime/Internal/WebSocketClientNonWebGL.cs
+++ b/Assets/Runtime/Internal/WebSocketClientNonWebGL.cs
@@ -11,35 +11,35 @@ namespace UnityWebSocket
 
         public async UniTask ConnectAsync(Uri uri, CancellationToken cancellationToken)
         {
-            await _client.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
+            await _client.ConnectAsync(uri, cancellationToken);
         }
 
         public async UniTask SendAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            await _client.SendAsync(buffer, WebSocketMessageType.Binary, true, cancellationToken).ConfigureAwait(false);
+            await _client.SendAsync(buffer, WebSocketMessageType.Binary, true, cancellationToken);
         }
 
         public async UniTask SendAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
         {
-            await _client.SendAsync(buffer, WebSocketMessageType.Binary, true, cancellationToken).ConfigureAwait(false);
+            await _client.SendAsync(buffer, WebSocketMessageType.Binary, true, cancellationToken);
         }
 
         public async UniTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer,
             CancellationToken cancellationToken)
         {
-            return await _client.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+            return await _client.ReceiveAsync(buffer, cancellationToken);
         }
 
         public async UniTask<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer,
             CancellationToken cancellationToken)
         {
-            return await _client.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+            return await _client.ReceiveAsync(buffer, cancellationToken);
         }
 
         public async UniTask CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription,
             CancellationToken cancellationToken)
         {
-            await _client.CloseAsync(closeStatus, statusDescription, cancellationToken).ConfigureAwait(false);
+            await _client.CloseAsync(closeStatus, statusDescription, cancellationToken);
         }
 
         public void Dispose()


### PR DESCRIPTION
Since the loop is run in the main thread in Unity, it would basically be easier to handle without switching SynchronizationContext with respect to WebSocket clients.